### PR TITLE
Fixes for MacOS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 TAGS
 log
+*.DS_Store

--- a/j1a/Makefile
+++ b/j1a/Makefile
@@ -33,10 +33,10 @@ endif
 
 ifeq ($(UNAME_S),Darwin)
 
-/dev/tty.usbserial-241B: mackextload
+/dev/tty.usbserial-*B: mackextload
 
-connect: /dev/tty.usbserial-241B
-	sudo python shell.py -h /dev/tty.usbserial-241B -p ../common/
+connect: /dev/tty.usbserial-*B
+	sudo python shell.py -h /dev/tty.usbserial-*B -p ../common/
 
 j4a: mackextunload
 	make -C icestorm j4a


### PR DESCRIPTION
The FTDI devices didn't always connect with the same number, this fixes that. 

Unfortunately it isn't portable to the linux case, so sometimes a similar issue breaks the Makefile when the FTDI doesn't get /dev/ttyUSB1 when it is plugged in.

In the mac case the two serial ports for each ftdi FT2232 are named ending in "A" and "B" rather than just being numbered sequentially. This makes a filename glob work for the mac ftdi driver in the desired way: The second of the two ports is the one connected through to the swapforth j1a or j4a.