### PR TITLE
The verilator testbench extended with possibility to dump the memory with all defined words to the hex file.

### DIFF
--- a/j1b/mem_dump.fs
+++ b/j1b/mem_dump.fs
@@ -1,0 +1,5 @@
+\ Written by Wojciech M. Zabolotny for the testbench with memory dump
+\ feature
+$2345 io@ \ Dump the memory to mem_dump.hex
+
+

--- a/j1b/user.fs
+++ b/j1b/user.fs
@@ -1,0 +1,4 @@
+\ Put your words here
+: user_test
+  ." This is a simple user defined word "
+;

--- a/j1b/verilator/j1b.v
+++ b/j1b/verilator/j1b.v
@@ -60,8 +60,8 @@ module j1b(input wire clk,
 
   // ######   UART   ##########################################
 
-  wire uart0_wr = io_wr_ & io_addr_[12];
-  wire uart0_rd = io_rd_ & io_addr_[12];
+  wire uart0_wr = io_wr_ & ( io_addr_ == 16'h1000 );
+  wire uart0_rd = io_rd_ & ( io_addr_ == 16'h1000 );
   assign uart_w = dout_[7:0];
 
   // always @(posedge clk) begin
@@ -79,7 +79,20 @@ module j1b(input wire clk,
   */
 
   assign io_din =
-    (io_addr_[12] ? {24'd0, uart0_data}                                  : 32'd0) |
-    (io_addr_[13] ? {28'd0, 1'b0, 1'b0, uart0_valid, 1'b1} : 32'd0);
+    (io_addr_ == 16'h1000 ? {24'd0, uart0_data}                                  : 32'd0) |
+    (io_addr_ == 16'h2000 ? {28'd0, 1'b0, 1'b0, uart0_valid, 1'b1} : 32'd0);
+
+   // ###### DUMP MEMORY FUNCTION #############################
+   int fout;
+   int i;   
+   always @(posedge clk) begin
+      if ( io_rd_ & ( io_addr_== 16'h2345 )) begin
+	   fout = $fopen("mem_dump.hex","w");
+           for(i=0;i<=8191;i++)
+		$fdisplay(fout,"%8.8h",ram[i]);
+	   $fclose(fout);
+      end
+   end
 
 endmodule
+

--- a/j1b/verilator/localtest_gen_hex
+++ b/j1b/verilator/localtest_gen_hex
@@ -1,0 +1,15 @@
+set -e
+make
+
+# ( echo
+#   python expand.py ../swapforth.fs ../../demos/factorials.fs
+#   echo 42 FAC .FAC
+# ) |
+# obj_dir/Vj1a ../build/nuc.hex
+# # grep 1,405,006,117,752,879,898,543,142,606,244,511,569,936,384,000,000,000
+
+echo |
+python shell.py -p ../ -p ../../common -p ../../anstests/ -p ../../../forth \
+-e '#noverbose' swapforth.fs \
+user.fs mem_dump.fs
+#../runtests.fs # ../../demos/factorials.fs

--- a/j1b/verilator/localtest_interactive
+++ b/j1b/verilator/localtest_interactive
@@ -1,0 +1,14 @@
+set -e
+make
+
+# ( echo
+#   python expand.py ../swapforth.fs ../../demos/factorials.fs
+#   echo 42 FAC .FAC
+# ) |
+# obj_dir/Vj1a ../build/nuc.hex
+# # grep 1,405,006,117,752,879,898,543,142,606,244,511,569,936,384,000,000,000
+
+#echo |
+python shell.py -p ../ -p ../../common -p ../../anstests/ -e '#noverbose' swapforth.fs \
+user.fs
+#../runtests.fs # ../../demos/factorials.fs


### PR DESCRIPTION
When working with the real hardware, the user defined words are stored in the file which must be later on transmitted via UART (e.g. the swapforth.fs) . That means, that initialization of the J1B may be time consuming.
Unfortunately, it is not possible to add the files with additional words to the list of files compiled by the crossassembler, as their format is different (e.g, they do not contain header definitions).
To allow the user to create the memory image with all currently defined words in a "nuc.hex" compatible format, I have added a virtual IO device to the Verilator testbench.
Each read from the $2345 IO port dumps the current program/data memory to the mem_dump.hex file.
If this file is used instead the original nuc.hex in the synthesis, the J1B in FPGA will have the same word definitions as the simulated J1B had at the moment of memory dumping.
That proces may be used even if the target J1B is equipped with the hardware not simulated in the Verilator testbench (the new words are only defined, not executed, so the lack of the related hardware is not a problem).
Connected with the possibility to define the "cold" word (which is executed immediately after the FPGA is configured and/or J1B exits the reset state), the proposed feature allows to synthesize J1B with embedded procedures for target board initialization. After the "cold" word returns, normal interactive work is resumed.

I have also added two scripts:

1. localtest_interactive: It allows to use the Verilator testbench to play with swapforth and to develop new words.
2. localtest_gen_hex: It automatically loads swapforth.fs and user.fs (with user defined words) and dumps the memory to the mem_dump.hex as described above.