### PR TITLE
unhelpful error message improved

### DIFF
--- a/shell/swapforth.py
+++ b/shell/swapforth.py
@@ -76,7 +76,7 @@ class TetheredTarget:
         try:
             import serial
         except:
-            print("This tool needs PySerial, but it was not found")
+            print("The PySerial python library modules is not installed. Please install via  pip install --user pyserial")    #("This tool needs PySerial, but it was not found")  /
             sys.exit(1)
         self.ser = serial.Serial(port, speed, timeout=None, rtscts=0)
 


### PR DESCRIPTION
think about it: "This tool needs PySerial, but it was not found"
what is "this" ?
what is "pyserial" ?  how to get it ?
on many levels, this message is super cryptic. seems, only Ruby tries to be more userfriendly.