### PR TITLE
fix the common include paths

### DIFF
--- a/j1a/swapforth.fs
+++ b/j1a/swapforth.fs
@@ -49,7 +49,7 @@
     postpone ;
 ;
 
-include core.fs
+include ../common/core.fs
 
 : /mod      >r s>d r> sm/rem ;
 : /         /mod nip ;
@@ -82,7 +82,7 @@ include core.fs
     here aligned
 ;
 
-include core-ext.fs
+include ../common/core-ext.fs
 
 : marker
     forth 2@        \ preserve FORTH and DP


### PR DESCRIPTION
fixes error when doing "#include swapforth.fs" according to the J1a SwapForth Reference guide:

```
u': create'
u'    :'
u'    here >body postpone literal'
u'    postpone ;'
u';'
u''
u'include core.fs'
Cannot find file core.fs in ['.']
```
