### PR TITLE
Modification needed to run the bootstrap in swapforth/j1b/verilator w…

### DIFF
--- a/j1b/verilator/shell.py
+++ b/j1b/verilator/shell.py
@@ -46,7 +46,7 @@ class TetheredJ1b(swapforth.TetheredTarget):
         for l in lines:
             l = l.split()
             s += [int(b, 16) for b in l[1:17]]
-        s = array.array('B', s).tostring().ljust(32768, chr(0xff))
+        s = array.array('B', s).tobytes().ljust(32768, bytearray((0xff,)))
         return array.array('i', s)
 
 if __name__ == '__main__':


### PR DESCRIPTION
…ith new version of Python 3.

Without that, an error occurs:

Traceback (most recent call last):
  File "/tmp/swapforth/j1b/verilator/shell.py", line 53, in <module>
    swapforth.main(TetheredJ1b)
  File "../../shell/swapforth.py", line 385, in main
    r.shell()
  File "../../shell/swapforth.py", line 339, in shell
    self.shellcmd(cmd)
  File "../../shell/swapforth.py", line 197, in shellcmd
    d = self.serialize()
  File "/tmp/rr/swapforth/j1b/verilator/shell.py", line 49, in serialize
    s = array.array('B', s).tostring().ljust(32768, chr(0xff))
AttributeError: 'array.array' object has no attribute 'tostring'